### PR TITLE
Create type-safe linkages between templates

### DIFF
--- a/cmd/muxt/testdata/F_is_defined_and_form_slice_field.txt
+++ b/cmd/muxt/testdata/F_is_defined_and_form_slice_field.txt
@@ -3,10 +3,10 @@
 muxt generate --receiver-type=T
 muxt check
 
+exec go build -o build
+
 -- in.go --
 package main
-
-import "net/http"
 
 type (
 	T  struct{}
@@ -16,6 +16,8 @@ type (
 )
 
 func (T) F(form In) int { return 0 }
+
+func main() {}
 -- template.go --
 package main
 

--- a/cmd/muxt/testdata/F_is_defined_and_form_type_is_a_struct.txt
+++ b/cmd/muxt/testdata/F_is_defined_and_form_type_is_a_struct.txt
@@ -3,6 +3,8 @@
 muxt generate --receiver-type=T
 muxt check
 
+exec go build -o build
+
 -- in.go --
 package main
 
@@ -14,6 +16,8 @@ type (
 )
 
 func (T) F(form In) int { return 0 }
+
+func main() {}
 -- template.go --
 package main
 

--- a/cmd/muxt/testdata/F_is_not_defined_and_a_form_field_is_passed.txt
+++ b/cmd/muxt/testdata/F_is_not_defined_and_a_form_field_is_passed.txt
@@ -3,10 +3,14 @@
 muxt generate --receiver-type=T
 muxt check
 
+exec go build -o build
+
 -- in.go --
 package main
 
 type T struct{}
+
+func main() {}
 -- template.go --
 package main
 

--- a/cmd/muxt/testdata/F_returns_a_value_and_a_boolean.txt
+++ b/cmd/muxt/testdata/F_returns_a_value_and_a_boolean.txt
@@ -3,12 +3,16 @@
 muxt generate --receiver-type=T
 muxt check
 
+exec go build -o build
+
 -- receiver.go --
 package main
 
 type T struct{}
 
 func (T) F(username string) (int, bool) { return 30, true }
+
+func main() {}
 -- template.go --
 package main
 

--- a/cmd/muxt/testdata/call_F.txt
+++ b/cmd/muxt/testdata/call_F.txt
@@ -3,6 +3,8 @@
 muxt generate --receiver-type=T
 muxt check
 
+exec go build -o build
+
 -- in.go --
 package main
 
@@ -19,6 +21,8 @@ import (
 var templatesDir embed.FS
 
 var templates = template.Must(template.ParseFS(templatesDir, "template.gohtml"))
+
+func main() {}
 -- go.mod --
 module example.com
 

--- a/cmd/muxt/testdata/call_F_with_argument_context.txt
+++ b/cmd/muxt/testdata/call_F_with_argument_context.txt
@@ -3,6 +3,8 @@
 muxt generate --receiver-type=T
 muxt check
 
+exec go build -o build
+
 -- in.go --
 package main
 
@@ -11,6 +13,8 @@ import "context"
 type T struct{}
 
 func (T) F(ctx context.Context) any { return nil }
+
+func main() {}
 -- template.go --
 package main
 

--- a/cmd/muxt/testdata/call_F_with_argument_path_param.txt
+++ b/cmd/muxt/testdata/call_F_with_argument_path_param.txt
@@ -3,12 +3,17 @@
 muxt generate --receiver-type=T
 
 muxt check
+
+exec go install
+
 -- in.go --
 package main
 
 type T struct{}
 
 func (T) F(param string) any { return nil }
+
+func main() {}
 -- template.go --
 package main
 

--- a/cmd/muxt/testdata/call_F_with_argument_response.txt
+++ b/cmd/muxt/testdata/call_F_with_argument_response.txt
@@ -3,6 +3,8 @@
 muxt generate --receiver-type=T
 muxt check
 
+exec go build -o build
+
 -- in.go --
 package main
 
@@ -11,6 +13,8 @@ import "net/http"
 type T struct{}
 
 func (T) F(response http.ResponseWriter) any { return nil }
+
+func main() {}
 -- template.go --
 package main
 

--- a/cmd/muxt/testdata/call_expression_argument_with_bool_last_result.txt
+++ b/cmd/muxt/testdata/call_expression_argument_with_bool_last_result.txt
@@ -3,11 +3,12 @@
 muxt generate --receiver-type=T
 muxt check
 
+exec go build -o build
+
 -- in.go --
 package main
 
 import (
-	"bytes"
 	"context"
 	"net/http"
 )
@@ -19,7 +20,9 @@ type (
 
 func (T) F(context.Context, S, int) any { return nil }
 
-func (T) Session(http.ResponseWriter, *http.Request) (S, bool) { return Session{}, false }
+func (T) Session(http.ResponseWriter, *http.Request) (S, bool) { return S{}, false }
+
+func main() {}
 -- template.go --
 package main
 

--- a/cmd/muxt/testdata/call_expression_argument_with_error_last_result.txt
+++ b/cmd/muxt/testdata/call_expression_argument_with_error_last_result.txt
@@ -3,13 +3,12 @@
 muxt generate --receiver-type=T
 muxt check
 
+exec go build -o build
+
 -- in.go --
 package main
 
-import (
-	"context"
-	"net/http"
-)
+import "context"
 
 type (
 	T       struct{}
@@ -19,6 +18,9 @@ type (
 func (T) F(context.Context, Session, int) any { return nil }
 
 func (T) Author(int) (Session, error) { return Session{}, nil }
+
+func main() {}
+
 -- template.go --
 package main
 

--- a/cmd/muxt/testdata/call_method_with_two_returns.txt
+++ b/cmd/muxt/testdata/call_method_with_two_returns.txt
@@ -3,14 +3,16 @@
 muxt generate --receiver-type=T
 muxt check
 
+exec go build -o build
+
 -- receiver.go --
 package main
 
-import "net/http"
-
 type T struct{}
 
-func (T) F(username string) (int, error) { return 30, error }
+func (T) F(username string) (int, error) { return 30, nil }
+
+func main() {}
 -- template.go --
 package main
 

--- a/cmd/muxt/testdata/form_basic_fields.txt
+++ b/cmd/muxt/testdata/form_basic_fields.txt
@@ -1,10 +1,14 @@
 muxt generate --receiver-type=T
 muxt check
 
+cat template_routes.go
+
+exec go test
+
 -- go.mod --
 module example.com
 
-go 1.20
+go 1.24
 -- template.go --
 package main
 
@@ -17,8 +21,10 @@ import (
 var templatesDir embed.FS
 
 var templates = template.Must(template.ParseFS(templatesDir, "template.gohtml"))
+
+func main() {}
 -- template.gohtml --
-{{- define "GET / F(form)" -}}
+{{- define "POST / F(form)" -}}
 FieldInt={{.Result.FieldInt}}
 FieldInt64={{.Result.FieldInt64}}
 FieldInt32={{.Result.FieldInt32}}
@@ -35,13 +41,12 @@ FieldTime={{.Result.FieldTime}}
 -- in.go --
 package main
 
-import (
-	"net/http"
-	"time"
-)
+import "time"
 
 type (
-	T  struct{}
+	T  struct{
+		spy func(form In) In
+	}
 	In struct {
 		FieldInt    int
 		FieldInt64  int64
@@ -60,35 +65,18 @@ type (
 
 func (T) F(form In) In { return form }
 -- template_test.go --
-package server
+package main
 
 import (
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"slices"
 	"strings"
 	"testing"
 )
 
 func Test(t *testing.T) {
-	mux := http.NewServeMux()
-
-	var service T
-
-	service.spy = func(form Form) Form {
-		if exp := []int{7, 14, 21, 29}; !slices.Equal(exp, form.Count) {
-			t.Errorf("exp %v, got %v", exp, form.Count)
-		}
-		if exp := "apple"; form.Str != exp {
-			t.Errorf("exp %v, got %v", exp, form.Str)
-		}
-		return form
-	}
-
-	TemplateRoutes(mux, service)
-
 	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(url.Values{
 		"FieldInt":    []string{"1"},
 		"FieldInt64":  []string{"2"},
@@ -100,23 +88,31 @@ func Test(t *testing.T) {
 		"FieldUint32": []string{"8"},
 		"FieldUint16": []string{"9"},
 		"FieldUint8":  []string{"10"},
-		"FieldBool":   []string{"11"},
-		"FieldTime":   []string{"12"},
+		"FieldBool":   []string{"true"},
+		"FieldTime":   []string{"2006-01-02T15:04:05Z"},
 	}.Encode()))
 	req.Header.Set("content-type", "application/x-www-form-urlencoded")
 	rec := httptest.NewRecorder()
 
+	service := T{
+		spy: func(form In) In {
+  		return form
+  	},
+	}
+	mux := http.NewServeMux()
+	TemplateRoutes(mux, service)
 	mux.ServeHTTP(rec, req)
 
 	res := rec.Result()
 
-	if res.StatusCode != http.StatusCreated {
-		t.Error("exp", http.StatusText(http.StatusCreated), "got", http.StatusText(res.StatusCode))
-	}
+		body, err := io.ReadAll(res.Body)
+    if err != nil {
+      t.Error(err)
+    }
+    t.Log(string(body))
 
-	body, err := io.ReadAll(res.Body)
-	if err != nil {
-		t.Error(err)
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("exp %q got %q", http.StatusText(http.StatusOK), http.StatusText(res.StatusCode))
 	}
 
 	for _, line := range []string{
@@ -130,8 +126,8 @@ func Test(t *testing.T) {
 		"FieldUint32=8",
 		"FieldUint16=9",
 		"FieldUint8=10",
-		"FieldBool=11",
-		"FieldTime=12",
+		"FieldBool=true",
+		"FieldTime=2006-01-02",
 	} {
 		if !strings.Contains(string(body), line) {
 			t.Errorf("%q not found", line)

--- a/cmd/muxt/testdata/form_html_has_a_cromulent_min_attribute.txt
+++ b/cmd/muxt/testdata/form_html_has_a_cromulent_min_attribute.txt
@@ -3,6 +3,8 @@
 muxt generate --receiver-type=T
 muxt check
 
+exec go build -o build
+
 -- in.go --
 package main
 
@@ -14,6 +16,8 @@ type (
 )
 
 func (T) F(form In) int { return 0 }
+
+func main() {}
 -- template.go --
 package main
 

--- a/cmd/muxt/testdata/function_in_package_simple.txt
+++ b/cmd/muxt/testdata/function_in_package_simple.txt
@@ -4,6 +4,8 @@ exec go test -cover
 
 muxt check
 
+exec go build -o build
+
 -- template.gohtml --
 {{define "GET / function(ctx)" }}{{.}}{{end}}
 
@@ -28,6 +30,8 @@ var templates = template.Must(template.ParseFS(formHTML, "*"))
 func function(ctx context.Context) int { return 32 }
 
 type Server struct{}
+
+func main() {}
 -- template_test.go --
 package server
 

--- a/cmd/muxt/testdata/no_handler.txt
+++ b/cmd/muxt/testdata/no_handler.txt
@@ -3,10 +3,14 @@
 muxt generate --receiver-type=T
 muxt check
 
+exec go build -o build
+
 -- in.go --
 package main
 
 type T struct{}
+
+func main() {}
 -- template.go --
 package main
 

--- a/cmd/muxt/testdata/path_param.txt
+++ b/cmd/muxt/testdata/path_param.txt
@@ -1,5 +1,7 @@
 muxt generate
 
+cat template_routes.go
+
 ! muxt check
 stderr 'checking endpoint GET /fruits/\{name\}/tree ToUpper\(name\)'
 stderr 'ERROR type check failed: template.gohtml:2:20: Name not found on any'

--- a/cmd/muxt/testdata/simple_call_larger_receiver_with_larger_package.txt
+++ b/cmd/muxt/testdata/simple_call_larger_receiver_with_larger_package.txt
@@ -3,6 +3,8 @@
 muxt generate --receiver-type=T
 muxt check
 
+exec go build -o build
+
 -- receiver.go --
 package main
 
@@ -11,6 +13,8 @@ type (
 
 	T struct{}
 )
+
+func main() {}
 -- f.go --
 package main
 

--- a/cmd/muxt/testdata/templates_multiple_embed_lines.txt
+++ b/cmd/muxt/testdata/templates_multiple_embed_lines.txt
@@ -5,6 +5,8 @@ stdout 'routes has route for POST /form'
 
 muxt check
 
+exec go build -o build ./cmd
+
 -- index.gohtml --
 {{define "GET /" }}
 	<h1>Hello, world!</h1>
@@ -20,7 +22,7 @@ muxt check
 {{end}}
 
 -- go.mod --
-module server
+module example.com/server
 
 go 1.22
 -- template.go --
@@ -36,3 +38,14 @@ import (
 var formHTML embed.FS
 
 var templates = template.Must(template.ParseFS(formHTML, "*"))
+
+type T struct{}
+
+-- cmd/main.go --
+package main
+
+import "example.com/server"
+
+var _ = server.T{}
+
+func main() {}

--- a/cmd/muxt/testdata/templates_multiple_globs.txt
+++ b/cmd/muxt/testdata/templates_multiple_globs.txt
@@ -5,6 +5,8 @@ stdout 'routes has route for POST /form'
 
 muxt check
 
+exec go build -o build ./cmd
+
 -- index.gohtml --
 {{define "GET /" }}
 	<h1>Hello, world!</h1>
@@ -20,9 +22,9 @@ muxt check
 {{end}}
 
 -- go.mod --
-module server
+module example.com
 
-go 1.22
+go 1.24
 -- template.go --
 package server
 
@@ -35,3 +37,14 @@ import (
 var formHTML embed.FS
 
 var templates = template.Must(template.ParseFS(formHTML, "*"))
+
+type T struct{}
+
+-- cmd/main.go --
+package main
+
+import server "example.com"
+
+var _ = server.TemplateRoutes
+
+func main() {}

--- a/cmd/muxt/testdata/templates_multiple_parsefs.txt
+++ b/cmd/muxt/testdata/templates_multiple_parsefs.txt
@@ -8,6 +8,8 @@ stderr 'checking endpoint GET /'
 stderr 'checking endpoint GET /form'
 stderr 'checking endpoint POST /form'
 
+exec go build -o build ./cmd
+
 -- index.gohtml --
 {{define "GET /" }}
 	<h1>Hello, world!</h1>
@@ -23,7 +25,7 @@ stderr 'checking endpoint POST /form'
 {{end}}
 
 -- go.mod --
-module server
+module example.com
 
 go 1.22
 -- template.go --
@@ -41,3 +43,12 @@ var indexHTML embed.FS
 var formHTML embed.FS
 
 var templates = template.Must(template.Must(template.ParseFS(formHTML, "*")).ParseFS(indexHTML, "*"))
+
+-- cmd/main.go --
+package main
+
+import server "example.com"
+
+var _ = server.TemplateRoutes
+
+func main() {}

--- a/example/hypertext/template_routes.go
+++ b/example/hypertext/template_routes.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"net/http"
+	"path"
 	"strconv"
 )
 
@@ -102,8 +103,28 @@ func TemplateRoutes(mux *http.ServeMux, receiver RoutesReceiver) {
 type TemplateData[T any] struct {
 	Request *http.Request
 	Result  T
+	Paths   TemplateRoutePaths
 }
 
 func newTemplateData[T any](result T, request *http.Request) TemplateData[T] {
 	return TemplateData[T]{Result: result, Request: request}
+}
+
+type TemplateRoutePaths struct {
+}
+
+func (TemplateRoutePaths) SubmitFormEditRow(id int) string {
+	return "/" + path.Join("fruits", strconv.Itoa(id))
+}
+
+func (TemplateRoutePaths) GetFormEditRow(id int) string {
+	return "/" + path.Join("fruits", strconv.Itoa(id), "edit")
+}
+
+func (TemplateRoutePaths) ReadHelp() string {
+	return "/help"
+}
+
+func (TemplateRoutePaths) List() string {
+	return "/"
 }

--- a/example/hypertext/template_routes.go
+++ b/example/hypertext/template_routes.go
@@ -124,6 +124,10 @@ func newTemplateData[T any](result T, request *http.Request) TemplateData[T] {
 type TemplateRoutePaths struct {
 }
 
+func TemplateRoutePath() TemplateRoutePaths {
+	return TemplateRoutePaths{}
+}
+
 func (TemplateRoutePaths) SubmitFormEditRow(id int) string {
 	return "/" + path.Join("fruits", strconv.Itoa(id))
 }

--- a/example/hypertext/template_routes.go
+++ b/example/hypertext/template_routes.go
@@ -101,13 +101,24 @@ func TemplateRoutes(mux *http.ServeMux, receiver RoutesReceiver) {
 }
 
 type TemplateData[T any] struct {
-	Request *http.Request
-	Result  T
-	Paths   TemplateRoutePaths
+	request *http.Request
+	result  T
+}
+
+func (TemplateData[T]) Path() TemplateRoutePaths {
+	return TemplateRoutePaths{}
+}
+
+func (data TemplateData[T]) Result() T {
+	return data.result
+}
+
+func (data TemplateData[T]) Request() *http.Request {
+	return data.request
 }
 
 func newTemplateData[T any](result T, request *http.Request) TemplateData[T] {
-	return TemplateData[T]{Result: result, Request: request}
+	return TemplateData[T]{result: result, request: request}
 }
 
 type TemplateRoutePaths struct {

--- a/example/hypertext/template_routes_test.go
+++ b/example/hypertext/template_routes_test.go
@@ -25,7 +25,7 @@ func TestRoutes(t *testing.T) {
 				f.SubmitFormEditRowReturns(hypertext.EditRowPage{Row: hypertext.Row{ID: 1, Name: "a", Value: 97}, Error: nil})
 			}),
 			When: func(t *testing.T) *http.Request {
-				req := httptest.NewRequest(http.MethodPatch, "/fruits/1", strings.NewReader(url.Values{"count": []string{"5"}}.Encode()))
+				req := httptest.NewRequest(http.MethodPatch, hypertext.TemplateRoutePath().SubmitFormEditRow(1), strings.NewReader(url.Values{"count": []string{"5"}}.Encode()))
 				req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 				return req
 			},
@@ -53,7 +53,7 @@ func TestRoutes(t *testing.T) {
 				f.GetFormEditRowReturns(hypertext.EditRowPage{Row: hypertext.Row{ID: 1, Name: "a", Value: 97}, Error: nil})
 			}),
 			When: func(t *testing.T) *http.Request {
-				return httptest.NewRequest(http.MethodGet, "/fruits/1/edit", nil)
+				return httptest.NewRequest(http.MethodGet, hypertext.TemplateRoutePath().GetFormEditRow(1), nil)
 			},
 			Then: func(t *testing.T, res *http.Response, f *fake.Backend) {
 				assert.Equal(t, http.StatusOK, res.StatusCode)

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.24
 
 require (
 	github.com/crhntr/dom v0.3.0
+	github.com/ettle/strcase v0.2.0
 	github.com/stretchr/testify v1.10.0
 	golang.org/x/net v0.35.0
 	golang.org/x/tools v0.30.0

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/crhntr/txtarfmt v0.0.7 h1:V1lmZ4PjmJvGAYdcP0YyTgUn3yfdCD6JNnwjWeT9bpw
 github.com/crhntr/txtarfmt v0.0.7/go.mod h1:6u3aUxZPnX1sYYxQE1nCRiQx802nucrcN4vToyuepco=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/ettle/strcase v0.2.0 h1:fGNiVF21fHXpX1niBgk0aROov1LagYsOwV/xqKDKR/Q=
+github.com/ettle/strcase v0.2.0/go.mod h1:DajmHElDSaX76ITe3/VHVyMin4LWSJN5Z909Wp+ED1A=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=

--- a/internal/muxt/check.go
+++ b/internal/muxt/check.go
@@ -10,7 +10,7 @@ import (
 	"golang.org/x/tools/go/packages"
 
 	"github.com/crhntr/muxt/internal/source"
-	typelate2 "github.com/crhntr/muxt/typelate"
+	"github.com/crhntr/muxt/typelate"
 )
 
 func CheckTemplates(wd string, log *log.Logger, config RoutesFileConfiguration) error {
@@ -47,8 +47,8 @@ func CheckTemplates(wd string, log *log.Logger, config RoutesFileConfiguration) 
 	if err != nil {
 		return err
 	}
-	fns := typelate2.DefaultFunctions(routesPkg.Types)
-	fns = fns.Add(typelate2.Functions(fm))
+	fns := typelate.DefaultFunctions(routesPkg.Types)
+	fns = fns.Add(typelate.Functions(fm))
 
 	var errs []error
 	for _, file := range routesPkg.Syntax {
@@ -59,7 +59,7 @@ func CheckTemplates(wd string, log *log.Logger, config RoutesFileConfiguration) 
 			}
 			log.Println("checking endpoint", templateName)
 			tree := ts.Lookup(templateName).Tree
-			if err := typelate2.Check(tree, dataType, routesPkg.Types, routesPkg.Fset, newForrest(ts), fns); err != nil {
+			if err := typelate.Check(tree, dataType, routesPkg.Types, routesPkg.Fset, newForrest(ts), fns); err != nil {
 				log.Println("ERROR", err)
 				log.Println()
 				errs = append(errs, err)

--- a/internal/muxt/name.go
+++ b/internal/muxt/name.go
@@ -36,9 +36,13 @@ func (t Template) generateEndpointPatternIdentifier(sb *strings.Builder) string 
 	}
 	var pathParams []string
 	if t.path == "/" {
+		if t.host != "" {
+			sb.WriteString(strcase.ToGoPascal(t.host))
+		}
 		sb.WriteString("Index")
 	} else {
-		pathSegments := strings.Split(t.path, "/")
+		pathSegments := []string{t.host}
+		pathSegments = append(pathSegments, strings.Split(t.path, "/")...)
 		for _, pathSegment := range pathSegments {
 			isPathParam := false
 			if len(pathSegment) > 2 && pathSegment[0] == '{' && pathSegment[len(pathSegment)-1] == '}' {

--- a/internal/muxt/name.go
+++ b/internal/muxt/name.go
@@ -1,0 +1,380 @@
+package muxt
+
+import (
+	"fmt"
+	"go/ast"
+	"go/token"
+	"go/types"
+	"net/http"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/ettle/strcase"
+
+	"github.com/crhntr/muxt/internal/source"
+)
+
+func (t Template) generateEndpointPatternIdentifier(sb *strings.Builder) string {
+	if sb == nil {
+		sb = new(strings.Builder)
+	}
+	sb.Reset()
+	switch t.method {
+	case http.MethodPost:
+		sb.WriteString("Create")
+	case http.MethodGet:
+		sb.WriteString("Read")
+	case http.MethodPut:
+		sb.WriteString("Replace")
+	case http.MethodPatch:
+		sb.WriteString("Update")
+	case http.MethodDelete:
+		sb.WriteString("Delete")
+	default:
+		sb.WriteString(strcase.ToGoPascal(t.method))
+	}
+	var pathParams []string
+	if t.path == "/" {
+		sb.WriteString("Index")
+	} else {
+		pathSegments := strings.Split(t.path, "/")
+		for _, pathSegment := range pathSegments {
+			isPathParam := false
+			if len(pathSegment) > 2 && pathSegment[0] == '{' && pathSegment[len(pathSegment)-1] == '}' {
+				pathSegment = pathSegment[1 : len(pathSegment)-1]
+				isPathParam = true
+			}
+			if len(pathSegment) == 0 {
+				continue
+			}
+			if pathSegment == "$" {
+				sb.WriteString("Index")
+				continue
+			}
+			pathSegment = strings.TrimRight(pathSegment, ".")
+			pathSegment = strcase.ToGoPascal(pathSegment)
+			if isPathParam {
+				pathParams = append(pathParams, pathSegment)
+				continue
+			}
+			sb.WriteString(pathSegment)
+		}
+	}
+	if len(pathParams) > 0 {
+		sb.WriteString("By")
+	}
+	for i, pathParam := range pathParams {
+		if len(pathParams) > 1 && i == len(pathParams)-1 {
+			sb.WriteString("And")
+		}
+		sb.WriteString(pathParam)
+	}
+	return sb.String()
+}
+
+func calculateIdentifiers(in []Template) {
+	var (
+		sb     strings.Builder
+		idents = make([]string, 0, len(in))
+		dupes  []string
+	)
+	for i, t := range in {
+		if t.fun != nil && t.fun.Name != "" {
+			ident := t.fun.Name
+			if j := slices.Index(idents, ident); j > 0 {
+				routePrev := in[j].generateEndpointPatternIdentifier(&sb)
+				idents[i] = routePrev + "Calling" + ident
+				route := t.generateEndpointPatternIdentifier(&sb)
+				idents = append(idents, route+"Calling"+t.fun.Name)
+				dupes = append(dupes, idents[j])
+				in[i].identifier = ident
+				continue
+			}
+			if slices.Contains(dupes, ident) {
+				route := t.generateEndpointPatternIdentifier(&sb)
+				idents = append(idents, route+"Calling"+t.fun.Name)
+				in[i].identifier = ident
+				continue
+			}
+			idents = append(idents, t.fun.Name)
+			in[i].identifier = ident
+			continue
+		}
+		ident := t.generateEndpointPatternIdentifier(&sb)
+		in[i].identifier = ident
+	}
+}
+
+type BasicPathSegment string
+
+func (segment BasicPathSegment) Expr() ast.Expr {
+	return &ast.BasicLit{
+		Kind:  token.STRING,
+		Value: strconv.Quote(string(segment)),
+	}
+}
+
+type HostSlashPathSegment string
+
+func (segment HostSlashPathSegment) Expr() ast.Expr {
+	return &ast.BasicLit{
+		Kind:  token.STRING,
+		Value: strconv.Quote(string(segment)),
+	}
+}
+
+type StringPathValuePathSegment string
+
+func (segment StringPathValuePathSegment) Expr() ast.Expr {
+	return ast.NewIdent(string(segment))
+}
+
+func encodeVariable(imports *source.Imports, name string, syntax ast.Expr, tp types.Type) (ast.Expr, error) {
+	basicType, ok := tp.Underlying().(*types.Basic)
+	if !ok {
+		return nil, fmt.Errorf("unsupported type %s for path parameters: %s", source.Format(syntax), name)
+	}
+	switch basicType.Kind() {
+	case types.Bool, types.UntypedBool:
+		return &ast.CallExpr{
+			Fun:  &ast.SelectorExpr{X: ast.NewIdent(imports.Add("", "strconv")), Sel: ast.NewIdent("FormatBool")},
+			Args: []ast.Expr{&ast.CallExpr{Fun: ast.NewIdent("bool"), Args: []ast.Expr{ast.NewIdent(name)}}},
+		}, nil
+	case types.Int, types.UntypedInt:
+		return &ast.CallExpr{
+			Fun:  &ast.SelectorExpr{X: ast.NewIdent(imports.Add("", "strconv")), Sel: ast.NewIdent("Itoa")},
+			Args: []ast.Expr{ast.NewIdent(name)},
+		}, nil
+	case types.Int8:
+		return &ast.CallExpr{
+			Fun:  &ast.SelectorExpr{X: ast.NewIdent(imports.Add("", "strconv")), Sel: ast.NewIdent("FormatInt")},
+			Args: []ast.Expr{&ast.CallExpr{Fun: ast.NewIdent("int64"), Args: []ast.Expr{ast.NewIdent(name)}}, source.Int(8)},
+		}, nil
+	case types.Int16:
+		return &ast.CallExpr{
+			Fun:  &ast.SelectorExpr{X: ast.NewIdent(imports.Add("", "strconv")), Sel: ast.NewIdent("FormatInt")},
+			Args: []ast.Expr{&ast.CallExpr{Fun: ast.NewIdent("int64"), Args: []ast.Expr{ast.NewIdent(name)}}, source.Int(16)},
+		}, nil
+	case types.Int32:
+		return &ast.CallExpr{
+			Fun:  &ast.SelectorExpr{X: ast.NewIdent(imports.Add("", "strconv")), Sel: ast.NewIdent("FormatInt")},
+			Args: []ast.Expr{&ast.CallExpr{Fun: ast.NewIdent("int64"), Args: []ast.Expr{ast.NewIdent(name)}}, source.Int(32)},
+		}, nil
+	case types.Int64:
+		return &ast.CallExpr{
+			Fun:  &ast.SelectorExpr{X: ast.NewIdent(imports.Add("", "strconv")), Sel: ast.NewIdent("FormatInt")},
+			Args: []ast.Expr{&ast.CallExpr{Fun: ast.NewIdent("int64"), Args: []ast.Expr{ast.NewIdent(name)}}, source.Int(64)},
+		}, nil
+	case types.Uint:
+		return &ast.CallExpr{
+			Fun:  &ast.SelectorExpr{X: ast.NewIdent(imports.Add("", "strconv")), Sel: ast.NewIdent("FormatUint")},
+			Args: []ast.Expr{&ast.CallExpr{Fun: ast.NewIdent("uint64"), Args: []ast.Expr{ast.NewIdent(name)}}, source.Int(64)},
+		}, nil
+	case types.Uint8:
+		return &ast.CallExpr{
+			Fun:  &ast.SelectorExpr{X: ast.NewIdent(imports.Add("", "strconv")), Sel: ast.NewIdent("FormatUint")},
+			Args: []ast.Expr{&ast.CallExpr{Fun: ast.NewIdent("uint64"), Args: []ast.Expr{ast.NewIdent(name)}}, source.Int(8)},
+		}, nil
+	case types.Uint16:
+		return &ast.CallExpr{
+			Fun:  &ast.SelectorExpr{X: ast.NewIdent(imports.Add("", "strconv")), Sel: ast.NewIdent("FormatUint")},
+			Args: []ast.Expr{&ast.CallExpr{Fun: ast.NewIdent("uint64"), Args: []ast.Expr{ast.NewIdent(name)}}, source.Int(16)},
+		}, nil
+	case types.Uint32:
+		return &ast.CallExpr{
+			Fun:  &ast.SelectorExpr{X: ast.NewIdent(imports.Add("", "strconv")), Sel: ast.NewIdent("FormatUint")},
+			Args: []ast.Expr{&ast.CallExpr{Fun: ast.NewIdent("uint64"), Args: []ast.Expr{ast.NewIdent(name)}}, source.Int(32)},
+		}, nil
+	case types.Uint64:
+		return &ast.CallExpr{
+			Fun:  &ast.SelectorExpr{X: ast.NewIdent(imports.Add("", "strconv")), Sel: ast.NewIdent("FormatUint")},
+			Args: []ast.Expr{ast.NewIdent(name), source.Int(64)},
+		}, nil
+	case types.String:
+		return ast.NewIdent(name), nil
+	default:
+		return nil, fmt.Errorf("unsupported basic type for path parameters: %s", name)
+	}
+}
+
+func routePathFunc(imports *source.Imports, t *Template) (*ast.FuncDecl, error) {
+	encodingPkg, ok := imports.Types("encoding")
+	if !ok {
+		return nil, fmt.Errorf(`the "encoding" package must be loaded`)
+	}
+	scope := encodingPkg.Scope()
+	textMarshalerObject := scope.Lookup("TextMarshaler")
+	textMarshalerType := textMarshalerObject.Type()
+	textMarshalerUnderlying := textMarshalerType.Underlying()
+	textMarshalerInterface := textMarshalerUnderlying.(*types.Interface)
+
+	method := &ast.FuncDecl{
+		Name: ast.NewIdent(t.identifier),
+		Recv: &ast.FieldList{
+			List: []*ast.Field{
+				{Type: ast.NewIdent(urlHelperTypeName)},
+			},
+		},
+		Type: &ast.FuncType{
+			Params:  &ast.FieldList{List: nil},
+			Results: &ast.FieldList{List: []*ast.Field{{Type: ast.NewIdent("string")}}},
+		},
+		Body: &ast.BlockStmt{
+			List: nil,
+		},
+	}
+
+	if t.path == "/" || t.path == "/{$}" {
+		method.Body.List = []ast.Stmt{&ast.ReturnStmt{Results: []ast.Expr{&ast.BasicLit{Kind: token.STRING, Value: `"/"`}}}}
+		return method, nil
+	}
+
+	templatePath, hasDollarSuffix := strings.CutSuffix(t.path, "{$}")
+	segmentStrings := strings.Split(templatePath, "/")
+	var (
+		fields []*ast.Field
+		last   types.Type
+
+		segmentExpressions []ast.Expr
+		identIndex         = 0
+
+		segmentIdentifiers = t.parsePathValueNames()
+	)
+	if len(segmentIdentifiers) == 0 {
+		method.Body.List = []ast.Stmt{&ast.ReturnStmt{Results: []ast.Expr{&ast.BasicLit{Kind: token.STRING, Value: strconv.Quote(templatePath)}}}}
+		return method, nil
+	}
+
+	for si, segment := range segmentStrings {
+		if len(segment) < 1 {
+			continue
+		}
+		if segment[0] != '{' || segment[len(segment)-1] != '}' {
+			if len(segmentExpressions) > 0 {
+				prev := segmentExpressions[len(segmentExpressions)-1]
+				if prevBasic, ok := prev.(*ast.BasicLit); ok {
+					prevVal, _ := strconv.Unquote(prevBasic.Value)
+					prevBasic.Value = strconv.Quote(prevVal + segment)
+					continue
+				}
+			}
+			segmentExpressions = append(segmentExpressions, &ast.BasicLit{
+				Kind:  token.STRING,
+				Value: strconv.Quote(segment),
+			})
+			continue
+		}
+
+		ident := segmentIdentifiers[identIndex]
+		pathValueType, ok := t.pathValueTypes[ident]
+		identIndex++
+		if !ok {
+			pathValueType = types.Universe.Lookup("string").Type()
+		}
+		tpNode, err := astTypeExpression(imports, pathValueType)
+		if err != nil {
+			return nil, err
+		}
+		if last != nil && len(fields) > 0 && types.Identical(last, pathValueType) {
+			fields[len(fields)-1].Names = append(fields[len(fields)-1].Names, ast.NewIdent(ident))
+			continue
+		}
+		fields = append(fields, &ast.Field{
+			Names: []*ast.Ident{ast.NewIdent(ident)},
+			Type:  tpNode,
+		})
+		last = pathValueType
+
+		if types.Implements(pathValueType, textMarshalerInterface) {
+			if len(method.Type.Results.List) == 1 {
+				method.Type.Results.List = append(method.Type.Results.List, &ast.Field{
+					Type: ast.NewIdent("error"),
+				})
+			}
+			segmentIdent := fmt.Sprintf("segment%d", si)
+			method.Body.List = append(method.Body.List, &ast.AssignStmt{
+				Rhs: []ast.Expr{&ast.CallExpr{
+					Fun: &ast.SelectorExpr{
+						X:   ast.NewIdent(ident),
+						Sel: ast.NewIdent("MarshalText"),
+					},
+				}},
+				Tok: token.DEFINE,
+				Lhs: []ast.Expr{
+					ast.NewIdent(segmentIdent),
+					ast.NewIdent("err"),
+				},
+			}, &ast.IfStmt{
+				Cond: &ast.BinaryExpr{X: ast.NewIdent(errIdent), Op: token.NEQ, Y: source.Nil()},
+				Body: &ast.BlockStmt{
+					List: []ast.Stmt{
+						&ast.ReturnStmt{
+							Results: []ast.Expr{
+								&ast.BasicLit{Kind: token.STRING, Value: `""`},
+								ast.NewIdent("err"),
+							},
+						},
+					},
+				},
+			})
+			segmentExpressions = append(segmentExpressions, ast.NewIdent(segmentIdent))
+			continue
+		}
+
+		exp, err := encodeVariable(imports, ident, tpNode, pathValueType)
+		if err != nil {
+			return nil, err
+		}
+		segmentExpressions = append(segmentExpressions, exp)
+	}
+
+	returnStmt := &ast.BinaryExpr{
+		X: &ast.BasicLit{
+			Kind:  token.STRING,
+			Value: strconv.Quote("/"),
+		},
+		Op: token.ADD,
+		Y: &ast.CallExpr{
+			Fun: &ast.SelectorExpr{
+				X:   ast.NewIdent(imports.Add("", "path")),
+				Sel: ast.NewIdent("Join"),
+			},
+			Args: segmentExpressions,
+		},
+	}
+	if hasDollarSuffix {
+		returnStmt = &ast.BinaryExpr{
+			X:  returnStmt,
+			Op: token.ADD,
+			Y: &ast.BasicLit{
+				Kind:  token.STRING,
+				Value: strconv.Quote("/"),
+			},
+		}
+	}
+
+	method.Body.List = append(method.Body.List, &ast.ReturnStmt{Results: []ast.Expr{returnStmt}})
+	method.Type.Params.List = fields
+
+	return method, nil
+}
+
+func routePathTypeAndMethods(imports *source.Imports, templates []Template, receiver *types.Named) ([]ast.Decl, error) {
+	decls := []ast.Decl{
+		&ast.GenDecl{
+			Tok: token.TYPE,
+			Specs: []ast.Spec{
+				&ast.TypeSpec{Name: ast.NewIdent(urlHelperTypeName), Type: &ast.StructType{Fields: &ast.FieldList{}}},
+			},
+		},
+	}
+	for _, t := range templates {
+		decl, err := routePathFunc(imports, &t)
+		if err != nil {
+			return nil, err
+		}
+		decls = append(decls, decl)
+	}
+	return decls, nil
+}

--- a/internal/muxt/name.go
+++ b/internal/muxt/name.go
@@ -372,6 +372,17 @@ func routePathTypeAndMethods(imports *source.Imports, templates []Template, rece
 				&ast.TypeSpec{Name: ast.NewIdent(urlHelperTypeName), Type: &ast.StructType{Fields: &ast.FieldList{}}},
 			},
 		},
+		&ast.FuncDecl{
+			Name: ast.NewIdent("TemplateRoutePath"),
+			Type: &ast.FuncType{Results: &ast.FieldList{List: []*ast.Field{{Names: []*ast.Ident{ast.NewIdent("")}, Type: ast.NewIdent(urlHelperTypeName)}}}},
+			Body: &ast.BlockStmt{
+				List: []ast.Stmt{
+					&ast.ReturnStmt{
+						Results: []ast.Expr{&ast.CompositeLit{Type: ast.NewIdent(urlHelperTypeName)}},
+					},
+				},
+			},
+		},
 	}
 	for _, t := range templates {
 		decl, err := routePathFunc(imports, &t)

--- a/internal/muxt/name_test.go
+++ b/internal/muxt/name_test.go
@@ -67,6 +67,18 @@ func TestTemplate_generateEndpointPatternIdentifier(t *testing.T) {
 			Out: "ReadX",
 			In:  "GET /x Method()",
 		},
+		{
+			Out: "ReadExampleComIndex",
+			In:  "GET example.com/ X()",
+		},
+		{
+			Out: "CreateABCDExampleComIndex",
+			In:  "POST a.b.c.d.example.com/ X()",
+		},
+		{
+			Out: "CreateExampleComPeach",
+			In:  "POST example.com/peach X()",
+		},
 	} {
 		t.Run(tt.Out, func(t *testing.T) {
 			pat, err, match := newTemplate(tt.In)

--- a/internal/muxt/name_test.go
+++ b/internal/muxt/name_test.go
@@ -1,0 +1,86 @@
+package muxt
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTemplate_generateEndpointPatternIdentifier(t *testing.T) {
+	for _, tt := range []struct {
+		In  string
+		Out string
+	}{
+		{
+			Out: "ReadIndex",
+			In:  "GET /",
+		},
+		{
+			Out: "ReadArticle",
+			In:  "GET /article",
+		},
+		{
+			Out: "CreateArticle",
+			In:  "POST /article",
+		},
+		{
+			Out: "UpdateArticle",
+			In:  "PATCH /article",
+		},
+		{
+			Out: "ReplaceArticle",
+			In:  "PUT /article",
+		},
+		{
+			Out: "DeleteArticle",
+			In:  "DELETE /article",
+		},
+		{
+			Out: "Article",
+			In:  "/article",
+		},
+		{
+			Out: "PeachPear",
+			In:  "/peach/pear",
+		},
+		{
+			Out: "PeachPearByPeachID",
+			In:  "/peach/{peachID}/pear",
+		},
+		{
+			Out: "PeachPearByPeachIDAndPearID",
+			In:  "/peach/{peachID}/pear/{pearID}",
+		},
+		{
+			Out: "PeachPearPlumByPeachIDAndPearID",
+			In:  "/peach/{peachID}/pear/{pearID}/plum",
+		},
+		{
+			Out: "PeachPearPlumIndexByPeachIDAndPearID",
+			In:  "/peach/{peachID}/pear/{pearID}/plum/{$}",
+		},
+		{
+			Out: "PlumPrune",
+			In:  "/plum-prune",
+		},
+		{
+			Out: "ReadX",
+			In:  "GET /x Method()",
+		},
+	} {
+		t.Run(tt.Out, func(t *testing.T) {
+			pat, err, match := newTemplate(tt.In)
+			require.True(t, match)
+			require.NoError(t, err)
+			require.Equal(t, tt.Out, pat.generateEndpointPatternIdentifier(nil))
+		})
+	}
+
+	t.Run("non standard http method", func(t *testing.T) {
+		e := Template{
+			method: "CONNECT",
+			path:   "/",
+		}
+		require.Equal(t, "ConnectIndex", e.generateEndpointPatternIdentifier(nil))
+	})
+}

--- a/internal/muxt/routes.go
+++ b/internal/muxt/routes.go
@@ -284,11 +284,11 @@ func TemplateRoutesFile(wd string, logger *log.Logger, config RoutesFileConfigur
 							},
 							Elts: []ast.Expr{
 								&ast.KeyValueExpr{
-									Key:   ast.NewIdent(templateDataTypeResultFieldName),
+									Key:   ast.NewIdent("result"),
 									Value: ast.NewIdent(resultParamName),
 								},
 								&ast.KeyValueExpr{
-									Key:   ast.NewIdent(httpRequestIdent),
+									Key:   ast.NewIdent("request"),
 									Value: ast.NewIdent(TemplateNameScopeIdentifierHTTPRequest),
 								},
 							},
@@ -333,11 +333,66 @@ func TemplateRoutesFile(wd string, logger *log.Logger, config RoutesFileConfigur
 						Type: &ast.StructType{
 							Fields: &ast.FieldList{
 								List: []*ast.Field{
-									{Names: []*ast.Ident{ast.NewIdent(httpRequestIdent)}, Type: imports.HTTPRequestPtr()},
-									{Names: []*ast.Ident{ast.NewIdent(templateDataTypeResultFieldName)}, Type: ast.NewIdent("T")},
-									{Names: []*ast.Ident{ast.NewIdent("Paths")}, Type: ast.NewIdent(urlHelperTypeName)},
+									{Names: []*ast.Ident{ast.NewIdent("request")}, Type: imports.HTTPRequestPtr()},
+									{Names: []*ast.Ident{ast.NewIdent("result")}, Type: ast.NewIdent("T")},
 								},
 							},
+						},
+					},
+				},
+			},
+
+			&ast.FuncDecl{
+				Recv: &ast.FieldList{List: []*ast.Field{{Type: &ast.IndexExpr{
+					X:     ast.NewIdent(templateDataTypeName),
+					Index: ast.NewIdent("T"),
+				}}}},
+				Name: ast.NewIdent("Path"),
+				Type: &ast.FuncType{
+					Results: &ast.FieldList{List: []*ast.Field{{Names: []*ast.Ident{ast.NewIdent("")}, Type: ast.NewIdent(urlHelperTypeName)}}},
+				},
+				Body: &ast.BlockStmt{
+					List: []ast.Stmt{
+						&ast.ReturnStmt{
+							Results: []ast.Expr{&ast.CompositeLit{Type: ast.NewIdent(urlHelperTypeName)}},
+						},
+					},
+				},
+			},
+
+			&ast.FuncDecl{
+				Recv: &ast.FieldList{List: []*ast.Field{{Names: []*ast.Ident{ast.NewIdent("data")},
+					Type: &ast.IndexExpr{
+						X:     ast.NewIdent(templateDataTypeName),
+						Index: ast.NewIdent("T"),
+					}}}},
+				Name: ast.NewIdent("Result"),
+				Type: &ast.FuncType{
+					Results: &ast.FieldList{List: []*ast.Field{{Type: ast.NewIdent("T")}}},
+				},
+				Body: &ast.BlockStmt{
+					List: []ast.Stmt{
+						&ast.ReturnStmt{
+							Results: []ast.Expr{&ast.SelectorExpr{X: ast.NewIdent("data"), Sel: ast.NewIdent("result")}},
+						},
+					},
+				},
+			},
+
+			&ast.FuncDecl{
+				Recv: &ast.FieldList{List: []*ast.Field{{Names: []*ast.Ident{ast.NewIdent("data")},
+					Type: &ast.IndexExpr{
+						X:     ast.NewIdent(templateDataTypeName),
+						Index: ast.NewIdent("T"),
+					}}}},
+				Name: ast.NewIdent("Request"),
+				Type: &ast.FuncType{
+					Results: &ast.FieldList{List: []*ast.Field{{Type: imports.HTTPRequestPtr()}}},
+				},
+				Body: &ast.BlockStmt{
+					List: []ast.Stmt{
+						&ast.ReturnStmt{
+							Results: []ast.Expr{&ast.SelectorExpr{X: ast.NewIdent("data"), Sel: ast.NewIdent("request")}},
 						},
 					},
 				},

--- a/internal/muxt/template.go
+++ b/internal/muxt/template.go
@@ -100,6 +100,15 @@ func newTemplate(in string) (Template, error, bool) {
 		}
 	}
 
+	if len(p.path) > 1 {
+		segments := strings.Split(p.path[1:], "/")
+		for _, segment := range segments {
+			if segment == "" {
+				return Template{}, fmt.Errorf("template has an empty path segment: %s", p.name), true
+			}
+		}
+	}
+
 	switch p.method {
 	default:
 		return p, fmt.Errorf("%s method not allowed", p.method), true

--- a/internal/muxt/template_internal_test.go
+++ b/internal/muxt/template_internal_test.go
@@ -446,6 +446,30 @@ func TestNewTemplateName(t *testing.T) {
 				require.ErrorContains(t, err, "you can not use response as an argument and specify an HTTP status code")
 			},
 		},
+		{
+			Name:     "empty middle path segment",
+			In:       "/x//y",
+			ExpMatch: true,
+			Error: func(t *testing.T, err error) {
+				require.ErrorContains(t, err, "template has an empty path segment:")
+			},
+		},
+		{
+			Name:     "empty first path segment",
+			In:       "//x/y",
+			ExpMatch: true,
+			Error: func(t *testing.T, err error) {
+				require.ErrorContains(t, err, "template has an empty path segment:")
+			},
+		},
+		{
+			Name:     "empty final path segment",
+			In:       "/x//",
+			ExpMatch: true,
+			Error: func(t *testing.T, err error) {
+				require.ErrorContains(t, err, "template has an empty path segment:")
+			},
+		},
 	} {
 		t.Run(tt.Name, func(t *testing.T) {
 			pat, err, match := newTemplate(tt.In)

--- a/internal/source/imports.go
+++ b/internal/source/imports.go
@@ -213,6 +213,7 @@ func (imports *Imports) SortImports() {
 }
 
 func (imports *Imports) AddNetHTTP() string      { return imports.Add("", "net/http") }
+func (imports *Imports) AddPath() string         { return imports.Add("", "path") }
 func (imports *Imports) AddHTMLTemplate() string { return imports.Add("", "html/template") }
 func (imports *Imports) AddContext() string      { return imports.Add("", "context") }
 


### PR DESCRIPTION
Given something like this
`<a href="{{.Paths.ReadUserByID .Result.AuthorID}}">Author</a>`

Muxt should know that this refers to something like `{{define "GET /user/{id}"}}{{end}}`