### PR TITLE
Allow handlers to override the default status code

### DIFF
--- a/cmd/muxt/testdata/argument_call_takes_response.txt
+++ b/cmd/muxt/testdata/argument_call_takes_response.txt
@@ -36,7 +36,11 @@ type T struct{}
 
 func (T) F(context.Context, any) any { return nil }
 
-func (T) Headers(response http.ResponseWriter) any { return nil }
+func (T) Headers(response http.ResponseWriter) any {
+	response.Header().Set("x-some-data", "123")
+	response.WriteHeader(http.StatusNotFound)
+	return nil
+}
 -- template_test.go --
 package main
 
@@ -80,10 +84,19 @@ func Test(t *testing.T) {
 
 	mux.ServeHTTP(res, req)
 
-	if res.WriteHeaderCallCount != 0 {
-		t.Error("unexpected WriteHeader call")
+	if res.WriteHeaderCallCount != 1 {
+		t.Errorf("unexpected WriteHeader count: want %d got %d", 1, res.WriteHeaderCallCount)
 	}
-	if res.HeaderCallCount != 0 {
-		t.Error("unexpected HeaderCall call")
+	if res.HeaderCallCount != 3 {
+		t.Errorf("unexpected Header call count: want %d got %d", 3, res.HeaderCallCount)
+	}
+	if val := rec.Result().Header.Get("x-some-data"); val != "123" {
+		t.Errorf("unexpected value for x-some-data: want %q got %q", "123", val)
+	}
+	if rec.Result().Header.Get("content-length") == "" {
+		t.Error("unexpected content-length to be set")
+	}
+	if rec.Result().Header.Get("content-type") == "" {
+		t.Error("unexpected content-type to be set")
 	}
 }

--- a/internal/source/imports.go
+++ b/internal/source/imports.go
@@ -307,6 +307,20 @@ func (imports *Imports) HTTPRequestPtr() *ast.StarExpr {
 	}
 }
 
+func (imports *Imports) HTTPResponseWriter() *ast.SelectorExpr {
+	return &ast.SelectorExpr{
+		X:   ast.NewIdent(imports.Add("http", "net/http")),
+		Sel: ast.NewIdent("ResponseWriter"),
+	}
+}
+
+func (imports *Imports) HTTPHeader() *ast.SelectorExpr {
+	return &ast.SelectorExpr{
+		X:   ast.NewIdent(imports.Add("http", "net/http")),
+		Sel: ast.NewIdent("Header"),
+	}
+}
+
 func (imports *Imports) StrconvParseInt8Call(in ast.Expr) *ast.CallExpr {
 	return imports.StrconvParseIntCall(in, 10, 8)
 }


### PR DESCRIPTION
This delays setting the status code until right before the Write call.

This will allow generated code to set the headers (Content-Type and Content-Length) with the correct values after the status code is set in the handler.